### PR TITLE
feat: added an autoload scene manager with fade in/fade out transitions

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -16,6 +16,10 @@ config/features=PackedStringArray("4.3", "Mobile")
 boot_splash/show_image=false
 config/icon="res://icon.svg"
 
+[autoload]
+
+SceneManager="*res://scenes/scene_manager.tscn"
+
 [dotnet]
 
 project/assembly_name="ggj"

--- a/scenes/scene_manager.tscn
+++ b/scenes/scene_manager.tscn
@@ -1,0 +1,76 @@
+[gd_scene load_steps=6 format=3 uid="uid://chmunp2f5jxs2"]
+
+[ext_resource type="Script" path="res://scripts/scene_manager.gd" id="1_70x1y"]
+
+[sub_resource type="Animation" id="Animation_qa8qj"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(0, 0, 0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_p4ajn"]
+resource_name = "fade_in"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(0, 0, 0, 0), Color(0, 0, 0, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_m73jf"]
+resource_name = "fade_out"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CanvasLayer/ColorRect:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(0, 0, 0, 1), Color(0, 0, 0, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_x7455"]
+_data = {
+"RESET": SubResource("Animation_qa8qj"),
+"fade_in": SubResource("Animation_p4ajn"),
+"fade_out": SubResource("Animation_m73jf")
+}
+
+[node name="SceneManager" type="Node"]
+script = ExtResource("1_70x1y")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+layer = 0
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="CanvasLayer"]
+root_node = NodePath("../..")
+libraries = {
+"": SubResource("AnimationLibrary_x7455")
+}
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+z_index = 20
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0)

--- a/scripts/menu.gd
+++ b/scripts/menu.gd
@@ -37,4 +37,4 @@ func _on_start_pressed() -> void:
 	#for node in nodes:
 	#	node.queue_free()
 	audio_player.play()
-	get_tree().change_scene_to_file("res://scenes/world.tscn")
+	SceneManager.change_scene("res://scenes/world.tscn")

--- a/scripts/scene_manager.gd
+++ b/scripts/scene_manager.gd
@@ -1,0 +1,29 @@
+extends Node
+
+@onready var animation_player: AnimationPlayer = $CanvasLayer/AnimationPlayer
+
+var current_scene
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	current_scene = get_tree().root.get_child(-1)
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func change_scene(path_scene):
+	_defered_change_scene(path_scene)
+
+func _defered_change_scene(path_scene):
+	SceneManager.animation_player.play("fade_in")
+	await SceneManager.animation_player.animation_finished
+
+	#get_tree().root.remove_child(current_scene)
+	current_scene.queue_free()
+	var new_scene = load(path_scene).instantiate()
+	current_scene = new_scene
+	get_tree().root.add_child(new_scene)
+	SceneManager.animation_player.play("fade_out")


### PR DESCRIPTION
A SceneManager [autoload (singleton)](https://docs.godotengine.org/en/latest/tutorials/scripting/singletons_autoload.html) has been defined in the project so future scene changes are handled in one class. This approach can also be used to handle the UI. 

To try it, open in the Godot editor `menu.tscn` and run the scene. 